### PR TITLE
Fix: Added handling for load Account

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -273,5 +273,5 @@ export class Mediator {
     /**
      * Dispose mediator account
      */
-    dispose(address: string): Promise<void>;
+    dispose(address?: string): Promise<void>;
 }


### PR DESCRIPTION
Load account was failing to await the error, so the try catch wasn't catching anything. Also, added check logic so that abnormal network errors wouldn't result in deleted public keys and loss of funds.